### PR TITLE
Add Express backend and configure frontend API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+frontend/node_modules/
+backend/node_modules/
+frontend/dist/
+backend/dist/
+.env
+backend/.env
+frontend/.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fullstack web application for downloading videos from TikTok, Instagram, and F
 
 ```
 video-downloader/
-├── frontend/           # React.js frontend
+├── frontend/           # React.js frontend (Vite)
 │   ├── src/
 │   │   ├── App.jsx    # Main application component
 │   │   ├── App.css    # Styles
@@ -25,21 +25,24 @@ video-downloader/
 └── backend/           # Node.js + Express backend
     ├── server.js     # Express server setup
     ├── utils.js      # Helper functions
-    └── package.json
+    ├── package.json
+    └── .env.example  # Environment variable template
 ```
 
 ## Setup and Installation
 
 ### Backend
 
-1. Navigate to the backend directory:
+1. Navigate to the backend directory and install dependencies:
    ```bash
    cd backend
+   npm install
    ```
 
-2. Install dependencies:
+2. Copy the environment template and update values as needed:
    ```bash
-   npm install
+   cp .env.example .env
+   # (optional) edit .env to set PORT or CLIENT_ORIGIN
    ```
 
 3. Start the development server:
@@ -47,18 +50,19 @@ video-downloader/
    npm run dev
    ```
 
-The backend server will run on http://localhost:5000
+The backend server will run on the configured `PORT` (defaults to `5000`).
 
 ### Frontend
 
-1. Navigate to the frontend directory:
+1. Navigate to the frontend directory and install dependencies:
    ```bash
    cd frontend
+   npm install
    ```
 
-2. Install dependencies:
+2. (Optional) Copy the provided environment example and adjust if necessary:
    ```bash
-   npm install
+   cp .env.example .env
    ```
 
 3. Start the development server:
@@ -66,7 +70,7 @@ The backend server will run on http://localhost:5000
    npm run dev
    ```
 
-The frontend will run on http://localhost:3000
+By default Vite serves the frontend on http://localhost:5173. Ensure the backend's `CLIENT_ORIGIN` matches this value.
 
 ## Important Note
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+PORT=5000
+CLIENT_ORIGIN=http://localhost:5173

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "video-downloader-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon server.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,47 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { resolveDownload } from './utils.js';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const rawOrigin = process.env.CLIENT_ORIGIN || 'http://localhost:5173';
+const allowOrigins = rawOrigin === '*'
+  ? rawOrigin
+  : rawOrigin.split(',').map((origin) => origin.trim());
+
+app.use(cors({
+  origin: allowOrigins,
+}));
+app.use(express.json());
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/download', async (req, res) => {
+  const { url } = req.body || {};
+
+  if (!url) {
+    return res.status(400).json({ error: 'Video URL is required' });
+  }
+
+  try {
+    const downloadUrl = await resolveDownload(url);
+
+    if (!downloadUrl) {
+      return res.status(404).json({ error: 'Unable to resolve download link for the provided URL' });
+    }
+
+    res.json({ downloadUrl });
+  } catch (error) {
+    console.error('Download error:', error);
+    res.status(500).json({ error: 'Unexpected server error' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend listening on port ${PORT}`);
+});

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1,0 +1,26 @@
+const PLACEHOLDER_PATTERNS = {
+  tiktok: /tiktok\.com/,
+  instagram: /instagram\.com/,
+  facebook: /facebook\.com/,
+};
+
+/**
+ * Resolve a download URL for a given social media link.
+ * This is a placeholder implementation that echoes the provided URL.
+ * Replace with real download resolution logic.
+ *
+ * @param {string} url
+ * @returns {Promise<string|null>}
+ */
+export async function resolveDownload(url) {
+  if (!url) return null;
+
+  const matchedPlatform = Object.entries(PLACEHOLDER_PATTERNS).find(([, pattern]) => pattern.test(url));
+
+  if (!matchedPlatform) {
+    return null;
+  }
+
+  // Placeholder: simply return the original URL; replace with actual download link.
+  return url;
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import './App.css';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+
 function App() {
   const [url, setUrl] = useState('');
   const [status, setStatus] = useState('');
@@ -16,7 +18,7 @@ function App() {
       setProgress(30);
       setError('');
 
-      const response = await axios.post('http://localhost:5000/api/download', { url });
+      const response = await axios.post(`${API_BASE_URL}/api/download`, { url });
       
       setProgress(60);
       

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,9 @@
-cumimport { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000
-  }
-})
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add an Express backend with configurable CORS and placeholder download resolution
- expose environment templates for both backend and frontend configuration
- update the React frontend to read the backend base URL from environment variables and fix the Vite dev server configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52ce5d88c8327bbfa01dbdd869c68