### PR TITLE
feat: expose yt-dlp metadata workflow

### DIFF
--- a/backend/src/controllers/downloadController.js
+++ b/backend/src/controllers/downloadController.js
@@ -2,7 +2,24 @@ import { downloadService } from '../services/downloadService.js';
 
 const URL_REGEX = /^(http(s)?:\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/;
 
-async function getDownloadLink(req, res, next) {
+function isValidFormatId(formatId) {
+  if (typeof formatId !== 'string') {
+    return false;
+  }
+
+  const trimmed = formatId.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.length > 100 || /[\r\n\t]/.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+}
+
+async function getVideoInfo(req, res, next) {
   try {
     const { url } = req.body || {};
 
@@ -14,19 +31,56 @@ async function getDownloadLink(req, res, next) {
       return res.status(400).json({ error: 'Please enter a valid URL' });
     }
 
-    const downloadUrl = await downloadService.resolveDownload(url);
-
-    if (!downloadUrl) {
-      return res.status(404).json({ error: 'This video platform is not supported or the link is invalid.' });
+    const info = await downloadService.fetchVideoInfo(url);
+    return res.json(info);
+  } catch (error) {
+    if (!error.statusCode) {
+      const wrappedError = new Error(
+        'Unable to fetch video information. Please verify the URL and try again.'
+      );
+      wrappedError.statusCode = 502;
+      wrappedError.cause = error;
+      return next(wrappedError);
     }
 
-    res.json({ downloadUrl });
+    return next(error);
+  }
+}
+
+async function getDownloadLink(req, res, next) {
+  try {
+    const { url, formatId } = req.body || {};
+
+    if (!url) {
+      return res.status(400).json({ error: 'Video URL is required' });
+    }
+
+    if (!URL_REGEX.test(url)) {
+      return res.status(400).json({ error: 'Please enter a valid URL' });
+    }
+
+    if (!isValidFormatId(formatId)) {
+      return res.status(400).json({ error: 'A valid formatId is required.' });
+    }
+
+    const downloadUrl = await downloadService.resolveDownload(url, formatId.trim());
+
+    return res.json({ downloadUrl });
   } catch (error) {
-    // Pass the error to the centralized error handler
-    next(error);
+    if (!error.statusCode) {
+      const wrappedError = new Error(
+        'Failed to generate a download link for the selected format. Please try again or choose another format.'
+      );
+      wrappedError.statusCode = 502;
+      wrappedError.cause = error;
+      return next(wrappedError);
+    }
+
+    return next(error);
   }
 }
 
 export const downloadController = {
+  getVideoInfo,
   getDownloadLink,
 };

--- a/backend/src/routes/downloadRoutes.js
+++ b/backend/src/routes/downloadRoutes.js
@@ -3,6 +3,7 @@ import { downloadController } from '../controllers/downloadController.js';
 
 const router = express.Router();
 
+router.post('/info', downloadController.getVideoInfo);
 router.post('/download', downloadController.getDownloadLink);
 
 export default router;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -226,6 +226,144 @@ body {
   font-weight: 500;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.video-result {
+  display: grid;
+  gap: 1.5rem;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-medium);
+  padding: 1.5rem;
+}
+
+.video-result__summary {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.video-result__thumbnail {
+  width: 160px;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: var(--radius-medium);
+  box-shadow: 0 10px 22px -18px rgba(15, 23, 42, 0.6);
+}
+
+.video-result__meta {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.video-result__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.video-result__label {
+  font-weight: 600;
+  color: var(--color-text-subtle);
+}
+
+.video-result__duration,
+.video-result__subtitles {
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.video-result__formats {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.format-table-wrapper {
+  overflow-x: auto;
+}
+
+.format-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.format-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  box-shadow: 0 15px 25px -20px rgba(15, 23, 42, 0.35);
+}
+
+.format-table th,
+.format-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 0.95rem;
+}
+
+.format-table th {
+  background: rgba(37, 99, 235, 0.08);
+  font-weight: 600;
+  color: var(--color-text-subtle);
+}
+
+.format-table tr:last-of-type td {
+  border-bottom: none;
+}
+
+.format-table__actions {
+  text-align: right;
+  width: 140px;
+}
+
+.format-download-button {
+  border: none;
+  border-radius: var(--radius-medium);
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.65rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.format-download-button:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px -16px rgba(37, 99, 235, 0.65);
+}
+
+.format-download-button:disabled {
+  cursor: not-allowed;
+  background: #94a3b8;
+  box-shadow: none;
+  transform: none;
+}
+
+.format-table__empty {
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--color-text-subtle);
+  border-radius: var(--radius-medium);
+  padding: 1rem;
+  font-size: 0.95rem;
+}
+
 .page__footer {
   margin-top: auto;
   text-align: center;
@@ -246,5 +384,22 @@ body {
 
   .platform-details ul {
     padding-left: 0;
+  }
+
+  .video-result {
+    padding: 1.25rem;
+  }
+
+  .video-result__summary {
+    flex-direction: column;
+  }
+
+  .video-result__thumbnail {
+    width: 100%;
+  }
+
+  .format-table__actions {
+    width: auto;
+    text-align: left;
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css';
 import { DownloadForm } from './components/DownloadForm';
 import { ErrorMessage } from './components/ErrorMessage';
 import { StatusIndicator } from './components/StatusIndicator';
+import { VideoInfoResult } from './components/VideoInfoResult';
 import { useDownloader } from './hooks/useDownloader';
 
 function App() {
@@ -13,8 +14,10 @@ function App() {
     error,
     validation,
     isProcessing,
+    videoInfo,
     handleUrlChange,
     handleSubmit,
+    handleFormatDownload,
     resetProgress,
   } = useDownloader();
 
@@ -44,6 +47,12 @@ function App() {
         />
 
         <ErrorMessage message={error} />
+
+        <VideoInfoResult
+          info={videoInfo}
+          onDownload={handleFormatDownload}
+          isBusy={isProcessing}
+        />
       </main>
 
       <footer className="page__footer">

--- a/frontend/src/components/DownloadForm.jsx
+++ b/frontend/src/components/DownloadForm.jsx
@@ -8,9 +8,13 @@ export function DownloadForm({
   onUrlChange,
   onSubmit,
 }) {
-  const helperMessage = validation.isValid
-    ? 'Paste a video link from TikTok, Instagram, or Facebook.'
-    : validation.message || 'Enter a valid video link to continue.';
+  const hasUrl = Boolean(url);
+  const helperMessage = hasUrl
+    ? validation.isValid
+      ? 'Click "Cari" to fetch video details and available formats.'
+      : validation.message || 'Enter a valid video link to continue.'
+    : 'Paste a video link to get started.';
+  const showErrorState = hasUrl && !validation.isValid;
 
   return (
     <form className="download-form" onSubmit={onSubmit} noValidate>
@@ -24,11 +28,11 @@ export function DownloadForm({
           value={url}
           onChange={(event) => onUrlChange(event.target.value)}
           placeholder="https://"
-          className={`url-input ${validation.isValid ? '' : 'url-input--invalid'}`}
+          className={`url-input ${showErrorState ? 'url-input--invalid' : ''}`}
           autoComplete="off"
           inputMode="url"
           required
-          aria-invalid={!validation.isValid}
+          aria-invalid={showErrorState}
           aria-describedby="url-helper"
           disabled={isProcessing}
         />
@@ -37,12 +41,12 @@ export function DownloadForm({
           className="download-button"
           disabled={isProcessing || !validation.isValid}
         >
-          {isProcessing ? 'Working...' : 'Download'}
+          {isProcessing ? 'Memproses...' : 'Cari'}
         </button>
       </div>
       <p
         id="url-helper"
-        className={`input-helper ${validation.isValid ? '' : 'input-helper--error'}`}
+        className={`input-helper ${showErrorState ? 'input-helper--error' : ''}`}
       >
         {helperMessage}
       </p>
@@ -71,3 +75,4 @@ DownloadForm.propTypes = {
   onUrlChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };
+

--- a/frontend/src/components/VideoInfoResult.jsx
+++ b/frontend/src/components/VideoInfoResult.jsx
@@ -1,0 +1,190 @@
+import PropTypes from 'prop-types';
+
+function formatDuration(seconds, fallback) {
+  if (typeof seconds !== 'number' || Number.isNaN(seconds) || seconds < 0) {
+    return fallback || 'Unknown duration';
+  }
+
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  const parts = [minutes.toString().padStart(2, '0'), secs.toString().padStart(2, '0')];
+
+  if (hours > 0) {
+    parts.unshift(hours.toString());
+  }
+
+  return parts.join(':');
+}
+
+function FormatsTable({ title, emptyMessage, formats, onDownload, disabled }) {
+  return (
+    <section className="format-section">
+      <h3>{title}</h3>
+      {formats.length > 0 ? (
+        <div className="format-table-wrapper">
+          <table className="format-table">
+            <thead>
+              <tr>
+                <th scope="col">Resolution</th>
+                <th scope="col">Ext</th>
+                <th scope="col">Note</th>
+                <th scope="col" className="format-table__actions">
+                  <span className="sr-only">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {formats.map((format) => (
+                <tr key={format.formatId}>
+                  <td data-label="Resolution">{format.resolution || 'Unknown'}</td>
+                  <td data-label="Ext">{format.ext}</td>
+                  <td data-label="Note">{format.note || '—'}</td>
+                  <td className="format-table__actions">
+                    <button
+                      type="button"
+                      className="format-download-button"
+                      onClick={() => onDownload(format)}
+                      disabled={disabled}
+                    >
+                      Download
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="format-table__empty">{emptyMessage}</p>
+      )}
+    </section>
+  );
+}
+
+FormatsTable.propTypes = {
+  title: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired,
+  formats: PropTypes.arrayOf(
+    PropTypes.shape({
+      formatId: PropTypes.string.isRequired,
+      resolution: PropTypes.string,
+      ext: PropTypes.string.isRequired,
+      type: PropTypes.oneOf(['video', 'audio']).isRequired,
+      note: PropTypes.string,
+    })
+  ).isRequired,
+  onDownload: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+FormatsTable.defaultProps = {
+  disabled: false,
+};
+
+export function VideoInfoResult({ info, onDownload, isBusy }) {
+  if (!info) {
+    return null;
+  }
+
+  const availableFormats = Array.isArray(info.formats) ? info.formats : [];
+
+  const videoFormats = [...availableFormats.filter((format) => format.type === 'video')].sort(
+    (a, b) => {
+      const toValue = (value) => {
+        const numeric = parseInt(value, 10);
+        return Number.isNaN(numeric) ? 0 : numeric;
+      };
+
+      return toValue(b.resolution) - toValue(a.resolution);
+    }
+  );
+
+  const audioFormats = [...availableFormats.filter((format) => format.type === 'audio')].sort(
+    (a, b) => {
+      const toValue = (value) => {
+        const numeric = parseInt(value, 10);
+        return Number.isNaN(numeric) ? 0 : numeric;
+      };
+
+      return toValue(b.resolution) - toValue(a.resolution);
+    }
+  );
+
+  const durationDisplay = info.durationFormatted || formatDuration(info.duration);
+
+  return (
+    <section className="video-result" aria-label="Video details">
+      <div className="video-result__summary">
+        {info.thumbnail && (
+          <img
+            src={info.thumbnail}
+            alt={info.title}
+            className="video-result__thumbnail"
+            loading="lazy"
+          />
+        )}
+        <div className="video-result__meta">
+          <h2 className="video-result__title">{info.title}</h2>
+          {durationDisplay && (
+            <p className="video-result__duration">
+              <span className="video-result__label">Duration:</span> {durationDisplay}
+            </p>
+          )}
+          {info.subtitles?.length > 0 && (
+            <p className="video-result__subtitles">
+              <span className="video-result__label">Subtitles:</span> {info.subtitles.join(', ')}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="video-result__formats">
+        <FormatsTable
+          title="Video Formats"
+          emptyMessage="No downloadable video formats were found."
+          formats={videoFormats}
+          onDownload={onDownload}
+          disabled={isBusy}
+        />
+
+        <FormatsTable
+          title="Audio Only"
+          emptyMessage="No audio-only formats are available."
+          formats={audioFormats}
+          onDownload={onDownload}
+          disabled={isBusy}
+        />
+      </div>
+    </section>
+  );
+}
+
+VideoInfoResult.propTypes = {
+  info: PropTypes.shape({
+    title: PropTypes.string,
+    thumbnail: PropTypes.string,
+    duration: PropTypes.number,
+    durationFormatted: PropTypes.string,
+    formats: PropTypes.arrayOf(
+      PropTypes.shape({
+        formatId: PropTypes.string.isRequired,
+        resolution: PropTypes.string,
+        ext: PropTypes.string.isRequired,
+        type: PropTypes.oneOf(['video', 'audio']).isRequired,
+        note: PropTypes.string,
+      })
+    ),
+    subtitles: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onDownload: PropTypes.func.isRequired,
+  isBusy: PropTypes.bool,
+};
+
+VideoInfoResult.defaultProps = {
+  info: null,
+  isBusy: false,
+};
+

--- a/frontend/src/services/videoDownloader.js
+++ b/frontend/src/services/videoDownloader.js
@@ -1,9 +1,19 @@
 import apiClient from './apiClient';
 
-export async function requestVideoDownload(url, signal) {
+export async function requestVideoInfo(url, signal) {
+  const response = await apiClient.post(
+    '/api/info',
+    { url },
+    { signal }
+  );
+
+  return response.data;
+}
+
+export async function requestVideoDownload(url, formatId, signal) {
   const response = await apiClient.post(
     '/api/download',
-    { url },
+    { url, formatId },
     { signal }
   );
 


### PR DESCRIPTION
## Summary
- add an `/api/info` endpoint and extend `/api/download` to validate inputs and return format-specific links via yt-dlp
- normalize yt-dlp metadata into titles, thumbnails, durations, formats, and subtitles for the frontend
- update the React UI to fetch video details, list available formats, and trigger downloads for a selected format

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d91249b4188327a9fb38ae38a6cbdf