### PR TITLE
Add real-time download progress via SSE

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "helmet": "^7.1.0",
         "node-cache": "^5.1.2",
         "pino": "^8.15.0",
+        "uuid": "^9.0.1",
         "yt-dlp-wrap": "^2.3.12"
       },
       "devDependencies": {
@@ -1649,6 +1650,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "node-cache": "^5.1.2",
     "pino": "^8.15.0",
+    "uuid": "^9.0.1",
     "yt-dlp-wrap": "^2.3.12"
   },
   "devDependencies": {

--- a/backend/src/routes/downloadRoutes.js
+++ b/backend/src/routes/downloadRoutes.js
@@ -4,6 +4,8 @@ import { downloadController } from '../controllers/downloadController.js';
 const router = express.Router();
 
 router.post('/info', downloadController.getVideoInfo);
-router.post('/download', downloadController.getDownloadLink);
+router.post('/prepare-download', downloadController.prepareDownload);
+router.get('/download-progress/:downloadId', downloadController.streamDownloadProgress);
+router.get('/get-file/:downloadId', downloadController.getFile);
 
 export default router;

--- a/backend/src/services/downloadService.js
+++ b/backend/src/services/downloadService.js
@@ -2,17 +2,115 @@ import YTDlpWrap from 'yt-dlp-wrap';
 import logger from './logger.js';
 import path from 'path';
 import fs from 'fs';
+import { promises as fsPromises } from 'fs';
 import NodeCache from 'node-cache';
 
 // Define a path for the yt-dlp binary within the backend directory
 const binaryPath = path.join(process.cwd(), 'yt-dlp.exe');
+const tempDirectory = path.join(process.cwd(), 'temp');
 let ytDlpWrap;
 const videoInfoCache = new NodeCache({ stdTTL: 3600 });
+const activeDownloads = new Map();
 
 function ensureYtDlp() {
   if (!ytDlpWrap) {
     throw new Error('yt-dlp is not initialized.');
   }
+}
+
+async function ensureTempDirectory() {
+  try {
+    await fsPromises.mkdir(tempDirectory, { recursive: true });
+  } catch (error) {
+    logger.error(error, 'Unable to create temporary download directory.');
+    throw error;
+  }
+}
+
+function sanitizePercent(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'string') {
+    const numeric = parseFloat(value.replace('%', ''));
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+
+  return 0;
+}
+
+function updateDownloadRecord(id, updates) {
+  const record = activeDownloads.get(id);
+  if (!record) {
+    return;
+  }
+
+  Object.assign(record, updates, { updatedAt: new Date().toISOString() });
+}
+
+function updateDownloadProgress(id, progressUpdates) {
+  const record = activeDownloads.get(id);
+  if (!record) {
+    return;
+  }
+
+  record.progress = {
+    ...record.progress,
+    ...progressUpdates,
+    percent: sanitizePercent(progressUpdates.percent ?? record.progress.percent),
+  };
+  record.updatedAt = new Date().toISOString();
+}
+
+async function findDownloadedFile(downloadId) {
+  try {
+    const entries = await fsPromises.readdir(tempDirectory);
+    for (const file of entries) {
+      if (!file.startsWith(`${downloadId}.`) || file.endsWith('.part')) {
+        continue;
+      }
+
+      const fullPath = path.join(tempDirectory, file);
+      try {
+        const stats = await fsPromises.stat(fullPath);
+        if (stats.isFile()) {
+          return fullPath;
+        }
+      } catch (statError) {
+        if (statError.code !== 'ENOENT') {
+          logger.warn(statError, `Unable to stat downloaded file candidate ${fullPath}`);
+        }
+      }
+    }
+
+    return null;
+  } catch (error) {
+    logger.error(error, `Unable to locate downloaded file for ${downloadId}`);
+    return null;
+  }
+}
+
+async function finalizeSuccessfulDownload(downloadId) {
+  const filePath = await findDownloadedFile(downloadId);
+  if (!filePath) {
+    updateDownloadRecord(downloadId, {
+      status: 'error',
+      error: 'The downloaded file could not be located on the server.',
+    });
+    return;
+  }
+
+  const fileName = path.basename(filePath);
+  updateDownloadRecord(downloadId, {
+    status: 'completed',
+    filePath,
+    fileName,
+  });
+  updateDownloadProgress(downloadId, {
+    percent: 100,
+    eta: '00:00',
+  });
 }
 
 function formatDuration(seconds) {
@@ -80,6 +178,7 @@ export async function initialize() {
   }
   // Initialize YTDlpWrap with the binary path
   ytDlpWrap = new YTDlpWrap.default(binaryPath);
+  await ensureTempDirectory();
 }
 
 /**
@@ -133,41 +232,155 @@ async function fetchVideoInfo(url) {
   }
 }
 
-/**
- * Resolve a download URL for a given social media link using yt-dlp.
- *
- * @param {string} url
- * @param {string} formatId
- * @returns {Promise<string>}
- */
-async function resolveDownload(url, formatId) {
+function createDownloadRecord(downloadId, url, formatId) {
+  const now = new Date().toISOString();
+  const record = {
+    id: downloadId,
+    url,
+    formatId,
+    status: 'pending',
+    error: null,
+    filePath: null,
+    fileName: null,
+    createdAt: now,
+    updatedAt: now,
+    progress: {
+      percent: 0,
+      totalSize: null,
+      currentSpeed: null,
+      eta: null,
+      downloaded: null,
+      statusText: 'pending',
+    },
+  };
+
+  activeDownloads.set(downloadId, record);
+  return record;
+}
+
+function attachDownloadListeners(downloadId, process) {
+  process.on('progress', (progress) => {
+    updateDownloadRecord(downloadId, { status: 'downloading' });
+    updateDownloadProgress(downloadId, {
+      percent: sanitizePercent(progress?.percent),
+      totalSize: progress?.totalSize ?? null,
+      currentSpeed: progress?.currentSpeed ?? null,
+      eta: progress?.eta ?? null,
+      downloaded: progress?.downloaded ?? null,
+      statusText: progress?.status ?? progress?.state ?? 'downloading',
+    });
+
+    if (progress?.filename) {
+      updateDownloadRecord(downloadId, { fileName: path.basename(progress.filename) });
+    }
+  });
+
+  process.once('error', (error) => {
+    logger.error(error, `yt-dlp process emitted an error for ${downloadId}`);
+    updateDownloadRecord(downloadId, {
+      status: 'error',
+      error: error?.message || 'Download process failed unexpectedly.',
+    });
+  });
+
+  process.once('close', (code) => {
+    if (code === 0) {
+      finalizeSuccessfulDownload(downloadId);
+    } else {
+      const message = `Download process exited with code ${code}.`;
+      logger.error(message, { downloadId });
+      updateDownloadRecord(downloadId, {
+        status: 'error',
+        error: message,
+      });
+    }
+  });
+}
+
+async function queueDownload(downloadId, url, formatId) {
   ensureYtDlp();
+  await ensureTempDirectory();
+
+  const record = createDownloadRecord(downloadId, url, formatId);
 
   try {
-    logger.info(`[yt-dlp] Attempting to get video URL for: ${url} (format: ${formatId})`);
+    const outputTemplate = path.join(tempDirectory, `${downloadId}.%(ext)s`);
+    logger.info(
+      `[yt-dlp] Starting download for ${url} (format: ${formatId}) -> ${outputTemplate}`
+    );
 
-    const videoUrl = await ytDlpWrap.execPromise([
-      url,
+    const args = [
       '-f',
       formatId,
-      '--get-url',
-    ]);
+      '-o',
+      outputTemplate,
+      '--no-part',
+      '--newline',
+      url,
+    ];
 
-    const firstUrl = videoUrl.split('\n').map((line) => line.trim()).find(Boolean);
-
-    if (!firstUrl) {
-      throw new Error('Download URL could not be resolved.');
-    }
-
-    logger.info(`[yt-dlp] Successfully retrieved URL: ${firstUrl}`);
-    return firstUrl;
+    const ytProcess = ytDlpWrap.exec(args);
+    attachDownloadListeners(downloadId, ytProcess);
   } catch (error) {
-    logger.error(error, `[yt-dlp] Error resolving download for ${url} (format: ${formatId})`);
+    logger.error(error, `Failed to spawn yt-dlp for ${url} (${formatId})`);
+    updateDownloadRecord(downloadId, {
+      status: 'error',
+      error: error?.message || 'Failed to start download process.',
+    });
     throw error;
   }
+
+  return record;
+}
+
+function getDownloadSnapshot(downloadId) {
+  const record = activeDownloads.get(downloadId);
+  if (!record) {
+    return null;
+  }
+
+  const { progress, ...rest } = record;
+  return {
+    ...rest,
+    progress: { ...progress },
+  };
+}
+
+function getDownloadFileInfo(downloadId) {
+  const record = activeDownloads.get(downloadId);
+  if (!record || !record.filePath) {
+    return null;
+  }
+
+  return {
+    filePath: record.filePath,
+    fileName: record.fileName ?? path.basename(record.filePath),
+  };
+}
+
+async function cleanupDownload(downloadId) {
+  const record = activeDownloads.get(downloadId);
+  if (!record) {
+    return;
+  }
+
+  if (record.filePath) {
+    try {
+      await fsPromises.unlink(record.filePath);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        logger.error(error, `Failed to delete temporary file for ${downloadId}`);
+      }
+    }
+  }
+
+  activeDownloads.delete(downloadId);
 }
 
 export const downloadService = {
   fetchVideoInfo,
-  resolveDownload,
+  queueDownload,
+  getDownloadSnapshot,
+  getDownloadFileInfo,
+  cleanupDownload,
 };

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -217,6 +217,87 @@ body {
   font-weight: 500;
 }
 
+.progress-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-top: 0.75rem;
+  color: var(--color-text-subtle);
+  font-size: 0.85rem;
+}
+
+.progress-details__item {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 120px;
+}
+
+.progress-details__item dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: var(--color-primary-dark);
+}
+
+.progress-details__item dd {
+  margin: 0;
+}
+
+.download-ready {
+  margin-top: 0.75rem;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  border-radius: var(--radius-medium);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.download-ready__meta {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.download-ready__label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  color: var(--color-primary-dark);
+}
+
+.download-ready__filename {
+  font-weight: 500;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.download-now-button {
+  border: none;
+  border-radius: var(--radius-medium);
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.download-now-button:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -16px rgba(37, 99, 235, 0.7);
+}
+
+.download-now-button:active {
+  transform: translateY(0);
+}
+
 .error-message {
   background: rgba(220, 38, 38, 0.12);
   border: 1px solid rgba(220, 38, 38, 0.35);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,11 +15,19 @@ function App() {
     validation,
     isProcessing,
     videoInfo,
+    downloadId,
+    progressDetails,
+    isDownloadReady,
+    downloadFileName,
     handleUrlChange,
     handleSubmit,
     handleFormatDownload,
+    handleDownloadNow,
     resetProgress,
   } = useDownloader();
+
+  const shouldHideFormats =
+    !videoInfo || status === 'downloading' || isDownloadReady;
 
   return (
     <div className="page">
@@ -43,16 +51,23 @@ function App() {
           status={status}
           statusMessage={statusMessage}
           progress={progress}
+          progressDetails={progressDetails}
+          isDownloadReady={isDownloadReady}
+          downloadFileName={downloadFileName}
+          hasDownloadId={Boolean(downloadId)}
+          onDownloadNow={handleDownloadNow}
           onReset={resetProgress}
         />
 
         <ErrorMessage message={error} />
 
-        <VideoInfoResult
-          info={videoInfo}
-          onDownload={handleFormatDownload}
-          isBusy={isProcessing}
-        />
+        {!shouldHideFormats && (
+          <VideoInfoResult
+            info={videoInfo}
+            onDownload={handleFormatDownload}
+            isBusy={isProcessing}
+          />
+        )}
       </main>
 
       <footer className="page__footer">

--- a/frontend/src/components/StatusIndicator.jsx
+++ b/frontend/src/components/StatusIndicator.jsx
@@ -1,15 +1,73 @@
 import PropTypes from 'prop-types';
 
-export function StatusIndicator({ status, statusMessage, progress, onReset }) {
-  if (!statusMessage && progress === 0) {
+export function StatusIndicator({
+  status,
+  statusMessage,
+  progress,
+  progressDetails,
+  isDownloadReady,
+  downloadFileName,
+  hasDownloadId,
+  onDownloadNow,
+  onReset,
+}) {
+  const showProgress = status === 'downloading' && !isDownloadReady;
+  const showDownloadReady = Boolean(isDownloadReady && hasDownloadId);
+  const hasProgressMeta = Boolean(
+    showProgress &&
+      (progressDetails?.downloaded ||
+        progressDetails?.totalSize ||
+        progressDetails?.currentSpeed ||
+        progressDetails?.eta)
+  );
+
+  if (!statusMessage && progress === 0 && !showProgress && !showDownloadReady) {
     return null;
   }
 
   return (
     <section className="status-container" aria-live="polite">
-      <div className="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={progress}>
-        <div className="progress-fill" style={{ width: `${progress}%` }} />
-      </div>
+      {showProgress && (
+        <>
+          <div
+            className="progress-bar"
+            role="progressbar"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow={progress}
+          >
+            <div className="progress-fill" style={{ width: `${Math.min(100, progress)}%` }} />
+          </div>
+          {hasProgressMeta && (
+            <dl className="progress-details">
+              {progressDetails?.downloaded && (
+                <div className="progress-details__item">
+                  <dt>Downloaded</dt>
+                  <dd>
+                    {progressDetails.downloaded}
+                    {progressDetails.totalSize
+                      ? ` / ${progressDetails.totalSize}`
+                      : ''}
+                  </dd>
+                </div>
+              )}
+              {progressDetails?.currentSpeed && (
+                <div className="progress-details__item">
+                  <dt>Speed</dt>
+                  <dd>{progressDetails.currentSpeed}</dd>
+                </div>
+              )}
+              {progressDetails?.eta && (
+                <div className="progress-details__item">
+                  <dt>ETA</dt>
+                  <dd>{progressDetails.eta}</dd>
+                </div>
+              )}
+            </dl>
+          )}
+        </>
+      )}
+
       <div className="status-row">
         <p className="status-text">{statusMessage}</p>
         {status === 'success' && (
@@ -18,6 +76,22 @@ export function StatusIndicator({ status, statusMessage, progress, onReset }) {
           </button>
         )}
       </div>
+
+      {showDownloadReady && (
+        <div className="download-ready">
+          <div className="download-ready__meta">
+            <p className="download-ready__label">Server download complete</p>
+            {downloadFileName && (
+              <p className="download-ready__filename" title={downloadFileName}>
+                {downloadFileName}
+              </p>
+            )}
+          </div>
+          <button type="button" className="download-now-button" onClick={onDownloadNow}>
+            Download Now
+          </button>
+        </div>
+      )}
     </section>
   );
 }
@@ -26,9 +100,26 @@ StatusIndicator.propTypes = {
   status: PropTypes.string.isRequired,
   statusMessage: PropTypes.string,
   progress: PropTypes.number.isRequired,
+  progressDetails: PropTypes.shape({
+    percent: PropTypes.number,
+    totalSize: PropTypes.string,
+    currentSpeed: PropTypes.string,
+    eta: PropTypes.string,
+    downloaded: PropTypes.string,
+    statusText: PropTypes.string,
+  }),
+  isDownloadReady: PropTypes.bool,
+  downloadFileName: PropTypes.string,
+  hasDownloadId: PropTypes.bool,
+  onDownloadNow: PropTypes.func,
   onReset: PropTypes.func.isRequired,
 };
 
 StatusIndicator.defaultProps = {
   statusMessage: '',
+  progressDetails: null,
+  isDownloadReady: false,
+  downloadFileName: '',
+  hasDownloadId: false,
+  onDownloadNow: () => {},
 };

--- a/frontend/src/services/videoDownloader.js
+++ b/frontend/src/services/videoDownloader.js
@@ -10,12 +10,27 @@ export async function requestVideoInfo(url, signal) {
   return response.data;
 }
 
-export async function requestVideoDownload(url, formatId, signal) {
+export async function prepareServerDownload(url, formatId, signal) {
   const response = await apiClient.post(
-    '/api/download',
+    '/api/prepare-download',
     { url, formatId },
     { signal }
   );
 
   return response.data;
+}
+
+function resolveApiBaseUrl() {
+  const baseURL = apiClient.defaults.baseURL || '';
+  return baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL;
+}
+
+export function createDownloadEventSource(downloadId) {
+  const baseUrl = resolveApiBaseUrl();
+  return new EventSource(`${baseUrl}/api/download-progress/${downloadId}`);
+}
+
+export function buildDownloadFileUrl(downloadId) {
+  const baseUrl = resolveApiBaseUrl();
+  return `${baseUrl}/api/get-file/${downloadId}`;
 }


### PR DESCRIPTION
## Summary
- orchestrate yt-dlp downloads on the server with UUID-tracked state, temporary storage, and cleanup
- expose prepare-download, progress streaming, and file retrieval endpoints backed by Server-Sent Events
- update the React client to subscribe to progress updates, render a detailed progress panel, and offer a final "Download Now" action

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d91a4b3f508327aa0443baba87a111