### PR TITLE
Handle subtitle download errors from blob responses

### DIFF
--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 const DEFAULT_TIMEOUT = 60000;
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000',
+  baseURL: import.meta?.env?.VITE_API_BASE_URL || 'http://localhost:5000',
   timeout: DEFAULT_TIMEOUT,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend/tests/videoDownloader.test.js
+++ b/frontend/tests/videoDownloader.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { downloadSubtitle } from '../src/services/videoDownloader.js';
+import apiClient from '../src/services/apiClient.js';
+
+test('downloadSubtitle throws backend error message when Blob response contains error', async () => {
+  const originalPost = apiClient.post;
+  const error = new Error('Request failed with status code 404');
+  error.response = {
+    data: new Blob([JSON.stringify({ error: 'Subtitle not found' })], {
+      type: 'application/json',
+    }),
+  };
+
+  apiClient.post = () => Promise.reject(error);
+
+  try {
+    await assert.rejects(
+      downloadSubtitle('https://example.com/video', 'en'),
+      (err) => {
+        assert.equal(err.message, 'Subtitle not found');
+        return true;
+      }
+    );
+  } finally {
+    apiClient.post = originalPost;
+  }
+});
+
+test('downloadSubtitle rethrows original error when response data is not a Blob', async () => {
+  const originalPost = apiClient.post;
+  const error = new Error('Request failed with status code 500');
+  error.response = {
+    data: { error: 'Server error' },
+  };
+
+  apiClient.post = () => Promise.reject(error);
+
+  try {
+    await assert.rejects(
+      downloadSubtitle('https://example.com/video', 'en'),
+      (err) => {
+        assert.equal(err, error);
+        return true;
+      }
+    );
+  } finally {
+    apiClient.post = originalPost;
+  }
+});


### PR DESCRIPTION
## Summary
- wrap subtitle download API calls in a try/catch and surface backend error messages from blob responses
- harden api client base URL resolution for non-Vite environments
- add automated tests covering subtitle download error handling

## Testing
- node --test frontend/tests/videoDownloader.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9e062a68c832797958aa68295214a