### PR TITLE
Fix yt-dlp-wrap usage without default property

### DIFF
--- a/backend/src/services/downloadService.js
+++ b/backend/src/services/downloadService.js
@@ -181,7 +181,7 @@ export async function initialize() {
   if (!fs.existsSync(binaryPath)) {
     logger.info(`Downloading yt-dlp binary to: ${binaryPath}`);
     try {
-      await YTDlpWrap.default.downloadFromGithub(binaryPath);
+      await YTDlpWrap.downloadFromGithub(binaryPath);
       logger.info('yt-dlp binary downloaded successfully.');
     } catch (error) {
       logger.error(error, 'Failed to download yt-dlp binary.');
@@ -191,7 +191,7 @@ export async function initialize() {
     logger.info('yt-dlp binary already exists.');
   }
   // Initialize YTDlpWrap with the binary path
-  ytDlpWrap = new YTDlpWrap.default(binaryPath);
+  ytDlpWrap = new YTDlpWrap(binaryPath);
   await ensureTempDirectory();
 }
 


### PR DESCRIPTION
## Summary
- update the download service to call `YTDlpWrap` methods without using the `.default` wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e1b171fc83278dc7d3284cff1084